### PR TITLE
syntax was never declared

### DIFF
--- a/cli/targets/proto.js
+++ b/cli/targets/proto.js
@@ -18,7 +18,7 @@ var Namespace = protobuf.Namespace,
 var out = [];
 var indent = 0;
 var first = false;
-var syntax = 3;
+var syntax = 3; 
 
 function proto_target(root, options, callback) {
 


### PR DESCRIPTION
added line 21:
var syntax = 3;

by the way, why not include the json->proto functionality into "util"?